### PR TITLE
Update site slogan to reflect open-source philosophy

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -56,7 +56,7 @@ const { title } = Astro.props;
     <meta name="theme-color" content="#ffffff" />
     <meta
       name="Description"
-      content="coolLabs: Control your digital footprint and privacy"
+      content="coolLabs: Software without compromise. Free, open source, and built for you."
     />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -64,7 +64,7 @@ const { title } = Astro.props;
     <meta name="twitter:title" content="coolLabs" />
     <meta
       name="twitter:description"
-      content="coolLabs: Control your digital footprint and privacy"
+      content="coolLabs: Software without compromise. Free, open source, and built for you."
     />
     <meta
       name="twitter:image"
@@ -75,7 +75,7 @@ const { title } = Astro.props;
     <meta property="og:title" content="coolLabs" />
     <meta
       property="og:description"
-      content="coolLabs: Control your digital footprint and privacy"
+      content="coolLabs: Software without compromise. Free, open source, and built for you."
     />
     <meta property="og:site_name" content="coolLabs" />
     <meta

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,10 @@ import BigSponsors from "./big-sponsors.astro";
 
 <Layout title="coolLabs">
   <h1 class="text-3xl font-bold tracking-tight text-white md:text-6xl px-4">
-    Control your digital footprint<span class="text-pink-500">.</span>
+    Software without compromise<span class="text-pink-500">.</span>
   </h1>
   <h2 class="text-base pt-2 text-neutral-400 px-4">
-    Free and open-source applications and services built for your online safety. <svg
+    Free, open source, and built for you. <svg
       class="w-6 h-6 inline-block"
       viewBox="0 0 36 36"
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
Updated the main slogan from "Control your digital footprint" to "Software without compromise" and the sub-slogan to "Free, open source, and built for you." This better reflects coolLabs' core values of freedom, accessibility, and transparency outlined in the philosophy page.

## Changes
- Updated homepage heading and subheading
- Updated meta descriptions (Open Graph, Twitter, and general meta tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)