### PR TITLE
fix(deps): remove swiper to address critical prototype pollution vulnerability

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,6 @@
         "daisyui": "^5.5.16",
         "postcss": "8.4.49",
         "svelte": "^5.49.1",
-        "swiper": "11.1.14",
         "tailwindcss": "^3.4.19",
         "typescript": "5.6.3",
       },
@@ -769,8 +768,6 @@
     "svelte2tsx": ["svelte2tsx@0.7.51", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0" } }, "sha512-YbVMQi5LtQkVGOMdATTY8v3SMtkNjzYtrVDGaN3Bv+0LQ47tGXu/Oc8ryTkcYuEJWTZFJ8G2+2I8ORcQVGt9Ag=="],
 
     "svgo": ["svgo@4.0.0", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.4.1" }, "bin": "./bin/svgo.js" }, "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw=="],
-
-    "swiper": ["swiper@11.1.14", "", {}, "sha512-VbQLQXC04io6AoAjIUWuZwW4MSYozkcP9KjLdrsG/00Q/yiwvhz9RQyt0nHXV10hi9NVnDNy1/wv7Dzq1lkOCQ=="],
 
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "daisyui": "^5.5.16",
     "postcss": "8.4.49",
     "svelte": "^5.49.1",
-    "swiper": "11.1.14",
     "tailwindcss": "^3.4.19",
     "typescript": "5.6.3"
   },


### PR DESCRIPTION
## Summary
- Removes swiper dependency (v11.1.14) due to critical prototype pollution vulnerability (CVE-2026-27212, GHSA-hmx5-qpq5-p643)
- Vulnerability affects swiper versions >=6.5.1, <12.1.2 and allows Object.prototype pollution via crafted Array.prototype manipulation
- Eliminates security risk without requiring package.json or bun.lock updates beyond dependency removal

## Breaking Changes
If your application directly imported or used swiper functionality, you will need to:
- Remove any swiper-dependent code from your components
- Consider alternative carousel/slider libraries if needed